### PR TITLE
General improvements

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Source the service account token from the container directly.
+export TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+
 redis-server /etc/redis/redis.conf &
 
 sed -i "s/ENDPOINT_PLACEHOLDER/$ENDPOINT/g" /var/www/html/kubeinvaders.js

--- a/openshift/KubeInvaders.yaml
+++ b/openshift/KubeInvaders.yaml
@@ -84,11 +84,6 @@ objects:
             value: "15"
           - name: HITSLIMIT
             value: "0"
-          - name: TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: "${KUBEINVADERS_SECRET}"
-                key: token
           name: kubeinvaders
           image: ${IMAGE_KUBEINVADERS}
           imagePullPolicy: Always 

--- a/openshift/KubeInvaders.yaml
+++ b/openshift/KubeInvaders.yaml
@@ -24,14 +24,7 @@ parameters:
   value: kubeinvaders
 - description: A namespaces to stress with KubeInvaders.
   name: TARGET_NAMESPACE
-- description: Secret of the serviceAccount that can kill PODs in specific namespace.
-  name: KUBEINVADERS_SECRET
 objects:
-- apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    name: kubeinvaders
-    namespace: ${NAMESPACE}
 - apiVersion: route.openshift.io/v1
   kind: Route
   metadata:


### PR DESCRIPTION
Service account token:

- Instead of injecting the token as an environment variable (and therefor needing to pull it from the service account before processing the template), use the token injected at runtime from the running container.

OpenShift template:
- Remove the "ServiceAccount" object, since the instructions ask you to pre-create the service account.
- Remove the "TOKEN" environment variable, as the token is now set in the `entrypoint.sh` script.