### PR TITLE
Pittar nginx log stdout

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Source the service account token from the container directly.
+export TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+
 redis-server /etc/redis/redis.conf &
 
 sed -i "s/ENDPOINT_PLACEHOLDER/$ENDPOINT/g" /var/www/html/kubeinvaders.js

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,5 +1,5 @@
 worker_processes  2;
-error_log  /var/log/nginx/error.log warn;
+error_log  /dev/stdout warn;
 pid        /var/run/nginx.pid;
 env REDIS_HOST;
 env TOKEN;
@@ -20,7 +20,7 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /var/log/nginx/access.log  main;
+    access_log  /dev/stdout  main;
     sendfile        on;
     keepalive_timeout  30;
     include /etc/nginx/conf.d/*.conf;

--- a/openshift/KubeInvaders.yaml
+++ b/openshift/KubeInvaders.yaml
@@ -84,11 +84,6 @@ objects:
             value: "15"
           - name: HITSLIMIT
             value: "0"
-          - name: TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: "${KUBEINVADERS_SECRET}"
-                key: token
           name: kubeinvaders
           image: ${IMAGE_KUBEINVADERS}
           imagePullPolicy: Always 

--- a/openshift/KubeInvaders.yaml
+++ b/openshift/KubeInvaders.yaml
@@ -24,14 +24,7 @@ parameters:
   value: kubeinvaders
 - description: A namespaces to stress with KubeInvaders.
   name: TARGET_NAMESPACE
-- description: Secret of the serviceAccount that can kill PODs in specific namespace.
-  name: KUBEINVADERS_SECRET
 objects:
-- apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    name: kubeinvaders
-    namespace: ${NAMESPACE}
 - apiVersion: route.openshift.io/v1
   kind: Route
   metadata:


### PR DESCRIPTION
Updated nginx config to log to `/dev/stdout` instead of a file.  This fixes permission issues on OpenShift, and also allows easier log aggregation and viewing.