### PR TITLE
update helm ingress template to new api version

### DIFF
--- a/helm-charts/kubeinvaders/templates/ingress.yaml
+++ b/helm-charts/kubeinvaders/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: kubeinvaders
@@ -22,8 +22,11 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: kubeinvaders
-          servicePort: 8080
+          service:
+            name: kubeinvaders
+            port:
+              number: 8080
 {{- end }}
 


### PR DESCRIPTION
Hey there!

I recently stumbled over this Game and had to try it. Nice Idea!

While deploying the chart using ingress I discovered that the ingress is still using the `extensions/v1beta` ingress API which was removed in Kubernetes v1.22.

So I updated the API and spec to match current state of art.