### PR TITLE
add extraEnv helm value for app settings

### DIFF
--- a/helm-charts/kubeinvaders/README.md
+++ b/helm-charts/kubeinvaders/README.md
@@ -19,3 +19,4 @@ helm install kubeinvaders --set-string target_namespace="namespace1\,namespace2"
 | image.tag           | Specify tag of KubeInvaders to deploy  |
 | ingress.hostName    | URL used for ingress                   |
 | target_namespace    | namespaces to take under control       |
+| extraEnv            | Extra environment variables for pod    |

--- a/helm-charts/kubeinvaders/templates/deployment.yaml
+++ b/helm-charts/kubeinvaders/templates/deployment.yaml
@@ -22,15 +22,18 @@ spec:
       serviceAccountName: kubeinvaders
       containers:
         - env:
-          {{ if .Values.ingress.enabled }}
+          {{- if .Values.ingress.enabled }}
           - name: ENDPOINT
             value: {{ required ".Values.ingress.hostName is required if Ingress are enabled" .Values.ingress.hostName }}
-          {{ else }}
+          {{- else }}
           - name: ENDPOINT
             value: {{ required ".Values.route_host is required if Ingress are disabled" .Values.route_host }}
-          {{ end }}
+          {{- end }}
           - name: NAMESPACE
             value: {{ .Values.target_namespace }}
+          {{- if .Values.extraEnv }}
+{{ toYaml .Values.extraEnv | indent 10 }}
+          {{- end }}
           name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/helm-charts/kubeinvaders/values.yaml
+++ b/helm-charts/kubeinvaders/values.yaml
@@ -39,13 +39,23 @@ ingress:
   enabled: true
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-  hostName: "" 
+  hostName: ""
   tls: {}
 
 # Use route_host only if ingress is disabled
 route_host: ""
 
 legacyIngress: false
+
+extraEnv: []
+# extraEnv:
+#   - name: ALIENPROXIMITY
+#     value: "10"
+#   - name: HITSLIMIT
+#     value: "1"
+#   - name: UPDATETIME
+#     value: "0.5"
+
 resources: {}
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
I noticed that in a previous revision of the README there was a section explaining how you can control the app's behaviour using env vars. However you were not able to set those vars using the chart and editing the existing deployment is cumbersome. So I added an `extraEnv` section (and an example) how to pass those settings using the helm values to the pod. Have a look.