### PR TITLE
add service monitor to helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Thumbs.db
 .project
 .cproject
 builtins
+.idea

--- a/helm-charts/kubeinvaders/templates/servicemonitor.yaml
+++ b/helm-charts/kubeinvaders/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kubeinvaders-metrics
+  labels:
+    app.kubernetes.io/name: kubeinvaders
+    helm.sh/chart: {{ include "kubeinvaders.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  endpoints:
+    - port: http
+  namespaceSelector: {}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubeinvaders
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm-charts/kubeinvaders/values.yaml
+++ b/helm-charts/kubeinvaders/values.yaml
@@ -59,3 +59,6 @@ extraEnv: []
 resources: {}
 nodeSelector: {}
 tolerations: []
+
+serviceMonitor:
+  enabled: false


### PR DESCRIPTION
This PR adds an optional service monitor resource to the helm chart to have the basic setup ready for the grafana dashboard