### PR TITLE
Add image to helm chart

### DIFF
--- a/helm-charts/kubeinvaders/Chart.yaml
+++ b/helm-charts/kubeinvaders/Chart.yaml
@@ -4,7 +4,7 @@ name: kubeinvaders
 appVersion: 1.9
 version: 1.9
 home: https://github.com/lucky-sideburn/KubeInvaders
-
+image: https://github.com/lucky-sideburn/KubeInvaders/blob/master/kubeinvaders.svg
 sources:
 - https://github.com/lucky-sideburn/KubeInvaders
 maintainers:


### PR DESCRIPTION
Adding an image to the helm chart makes it look nicer while using tools like lens and kubeapps.