### PR TITLE
Helm: add additional labels to resources

### DIFF
--- a/helm-charts/kubeinvaders/templates/deployment.yaml
+++ b/helm-charts/kubeinvaders/templates/deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     helm.sh/chart: {{ include "kubeinvaders.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.additionalLabels }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.deployment.replicaCount }}
   selector:
@@ -18,6 +21,9 @@ spec:
       labels:
         app.kubernetes.io/name: kubeinvaders
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.additionalLabels }}
+        {{- . | toYaml | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: kubeinvaders
       {{- with .Values.deployment.securityContext }}

--- a/helm-charts/kubeinvaders/templates/ingress.yaml
+++ b/helm-charts/kubeinvaders/templates/ingress.yaml
@@ -8,6 +8,9 @@ metadata:
     helm.sh/chart: {{ include "kubeinvaders.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.additionalLabels }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/helm-charts/kubeinvaders/templates/rbac-cluster.yaml
+++ b/helm-charts/kubeinvaders/templates/rbac-cluster.yaml
@@ -9,6 +9,9 @@ metadata:
     chart: {{ template "kubeinvaders.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- with .Values.additionalLabels }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
 rules:
 - apiGroups: [""]
   resources: ["pods", "pods/log"]

--- a/helm-charts/kubeinvaders/templates/rbac.yaml
+++ b/helm-charts/kubeinvaders/templates/rbac.yaml
@@ -8,6 +8,9 @@ metadata:
     chart: {{ template "kubeinvaders.chart" $ }}
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
+    {{- with .Values.additionalLabels }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
 rules:
 - apiGroups: [""]
   resources: ["pods", "pods/log", "jobs"]

--- a/helm-charts/kubeinvaders/templates/service.yaml
+++ b/helm-charts/kubeinvaders/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     helm.sh/chart: {{ include "kubeinvaders.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.additionalLabels }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/helm-charts/kubeinvaders/templates/serviceaccount.yaml
+++ b/helm-charts/kubeinvaders/templates/serviceaccount.yaml
@@ -9,3 +9,6 @@ metadata:
     chart: {{ template "kubeinvaders.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- with .Values.additionalLabels }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}

--- a/helm-charts/kubeinvaders/templates/servicemonitor.yaml
+++ b/helm-charts/kubeinvaders/templates/servicemonitor.yaml
@@ -8,6 +8,9 @@ metadata:
     helm.sh/chart: {{ include "kubeinvaders.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.additionalLabels }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
     - port: http

--- a/helm-charts/kubeinvaders/values.yaml
+++ b/helm-charts/kubeinvaders/values.yaml
@@ -5,6 +5,9 @@
 nameOverride: ""
 fullnameOverride: ""
 
+# Additional labels for resources
+additionalLabels: {}
+
 config:
   # target_namespace where kubeinvaders should be allowed to kill pods
   target_namespace: "default"


### PR DESCRIPTION
Some environments often enforce labeling policies that doesn't allow to run workloads without certain mandatory labels.
This PR adds the ability to configure labels in the chart values for all the resources created by the Helm chart.