### PR TITLE
Helm: Add Grafana dashboard for Grafana Operator

### DIFF
--- a/helm-charts/kubeinvaders/dashboards/KubeInvadersDashboard.json
+++ b/helm-charts/kubeinvaders/dashboards/KubeInvadersDashboard.json
@@ -1,0 +1,1 @@
+../../../grafana/KubeInvadersDashboard.json

--- a/helm-charts/kubeinvaders/templates/grafanadashboard.yaml
+++ b/helm-charts/kubeinvaders/templates/grafanadashboard.yaml
@@ -1,0 +1,43 @@
+{{ if .Values.grafanaDashboard.enabled }}
+{{ $currentScope := .}}
+{{ range $path, $_ :=  .Files.Glob  "dashboards/**.json" }}
+{{ $dashboardName := regexReplaceAll "(^.*/)(.*)\\.json$" $path "${2}" }}
+{{- with $currentScope}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "grafana-dashboards-{{ lower $dashboardName }}"
+  labels:
+    app.kubernetes.io/name: kubeinvaders
+    helm.sh/chart: {{ include "kubeinvaders.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.additionalLabels }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
+data:
+  {{- (.Files.Glob $path).AsConfig | nindent 2 }}
+---
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: "grafana-dashboards-{{ lower $dashboardName }}"
+  labels:
+    app.kubernetes.io/name: kubeinvaders
+    helm.sh/chart: {{ include "kubeinvaders.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.additionalLabels }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
+spec:
+  datasources:
+    - inputName: "DS_PROMETHEUS"
+      datasourceName: "Prometheus"
+  configMapRef:
+    name: "grafana-dashboards-{{ lower $dashboardName }}"
+    key: {{ $dashboardName }}.json
+{{- end }}
+{{ end }}
+{{ end }}

--- a/helm-charts/kubeinvaders/values.yaml
+++ b/helm-charts/kubeinvaders/values.yaml
@@ -67,3 +67,8 @@ route_host: ""
 
 serviceMonitor:
   enabled: false
+
+# Create Grafana Dashboard CRD and configmap for Grafana operator
+grafanaDashboard:
+  enabled: false
+  labels: {} # Labels configured in Grafana operator as dashboardLabelSelector


### PR DESCRIPTION
- This PR adds Grafana Operator resources required to install the included Grafana dashboard.
- It adds a symlink to the dashboard file from the dashboards folder inside the helm chart folder.
- It allows to configure the Grafana selector label configured for the operator to pick up the CRDs.
- This PR includes the changes in #55 in a separate merge commit (it can be cherry picked)
Feel free to discard the PR if it doesn't make sense 😄 