### PR TITLE
Programming mode: Add addtional-labels to jobs pod specs

### DIFF
--- a/scripts/programming_mode/experiments.yaml
+++ b/scripts/programming_mode/experiments.yaml
@@ -33,6 +33,8 @@ jobs:
   mem-attack:
     image: docker.io/luckysideburn/kubeinvaders-stress-ng:latest
     command: "stress-ng"
+    additional-labels:
+      test-label: "test"
     args:
       - --help
 


### PR DESCRIPTION
Hello again! 

I've been playing around with the programming mode, having lots of fun so far! 

This PR modifies the generation of the pod template to include the optional `additional-labels` property to the job definition.
The reasons are the same as in PR #55 

```yaml
jobs:
  mem-attack:
    image: docker.io/luckysideburn/kubeinvaders-stress-ng:latest
    command: "stress-ng"
    additional-labels:
      test-label: "test"
    args:
      - --help
```
which would generate a job with a pod template like:

```
INFO:root:pod_template = {'metadata': {'annotations': None,
              'creation_timestamp': None,
              'deletion_grace_period_seconds': None,
              'deletion_timestamp': None,
              'finalizers': None,
              'generate_name': None,
              'generation': None,
              'labels': {'app': 'kubeinvaders',
                         'approle': 'chaosnode',
                         'pod_name': 'mem-attack-exp',
                         'test-label': 'test'},
              'managed_fields': None,
              'name': 'mem-attack-exp',
              'namespace': None,
              'owner_references': None,
              'resource_version': None,
```

Thanks again for all your work!