### PR TITLE
Helm: Add missing common label to pod metadata labels

### DIFF
--- a/helm-charts/kubeinvaders/templates/deployment.yaml
+++ b/helm-charts/kubeinvaders/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: kubeinvaders
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
         {{- with .Values.additionalLabels }}
         {{- . | toYaml | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
Hello @lucky-sideburn ! 
Sorry for the small PR, it adds missing common label `app.kubernetes.io/managed-by` to pod metadata labels: https://kubernetes.io/docs/reference/labels-annotations-taints/#app-kubernetes-io-managed-by