### PR TITLE
Fixed the create kubectl namespace commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ TOKEN=$(k get secret -n kubeinvaders -o go-template='{{.data.token | base64decod
 Create two namespaces:
 
 ```bash
-kubectl create namespace1
-kubectl create namespace2
+kubectl create namespace namespace1
+kubectl create namespace namespace2
 ```
 Run the container:
 


### PR DESCRIPTION
The correct way to create a namespace in kubectl is with `kubectl create namespace <namespace_name>`. The current example will cause an error. 