### PR TITLE
Update redis.conf bind configuration to only listen on IPv6 loopback if available

### DIFF
--- a/confs/redis/redis.conf
+++ b/confs/redis/redis.conf
@@ -1,4 +1,4 @@
-bind 127.0.0.1 ::1
+bind 127.0.0.1 -::1
 unixsocket /tmp/redis.sock
 unixsocketperm 777
 protected-mode yes


### PR DESCRIPTION
The current Redis configuration in the project causes Redis to fail to start when running on a host without an IPv6 networking stack with the following error:

```
Warning: Could not create server TCP listening socket ::1:6379: bind: Cannot assign requested address
Failed listening on port 6379 (TCP), aborting.
```

I've updated the configuration to reflect the default redis config that only binds to the IPv6 loopback if it's available.

See: https://redis.io/docs/latest/operate/oss_and_stack/management/config-file/