### PR TITLE
Improved Makefile for minikube installation

### DIFF
--- a/minikube-setup/Makefile
+++ b/minikube-setup/Makefile
@@ -3,25 +3,48 @@ driver?=virtualbox
 memory?=2048
 cpu?=4
 nodes?=1
+image_tag?=latest
 
+MAKEFILE_DIRECTORY:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 .PHONY: init-cluster
 init-cluster:
 	minikube start \
-        --kubernetes-version $(kubernetes-version) \
-        --driver $(driver) \
-        --memory $(memory) \
-        --cpus $(cpu) \
-        --nodes $(nodes) \
-        --embed-certs  \
+		--kubernetes-version $(kubernetes-version) \
+		--driver $(driver) \
+		--memory $(memory) \
+		--cpus $(cpu) \
+		--nodes $(nodes) \
+		--embed-certs  \
 		--static-ip 10.211.55.70
 
 
 .PHONY: setup-cluster
 setup-cluster: 
-	kubectl apply -f manifests && helm install kubeinvaders --set-string config.target_namespace="ns-1" \
-	-n kubeinvaders kubeinvaders/kubeinvaders --set ingress.enabled=true --set ingress.hostName=kubeinvaders.local --set deployment.image.tag=v1.9.6 && minikube addons enable ingress
+	kubectl apply -f ${MAKEFILE_DIRECTORY}/manifests \
+		&& helm upgrade --install kubeinvaders \
+			--set-string config.target_namespace="ns-1" \
+			-n kubeinvaders \
+			kubeinvaders/kubeinvaders \
+			--set ingress.enabled=true \
+			--set ingress.hostName=kubeinvaders.local \
+			--set deployment.image.tag=$(image_tag) \
+		&& minikube addons enable ingress
 
+.PHONY: dev-cluster
+dev-cluster:
+	kubectl apply -f ${MAKEFILE_DIRECTORY}/manifests \
+		&& helm upgrade --install kubeinvaders \
+			--set-string config.target_namespace="ns-1" \
+			-n kubeinvaders \
+			${MAKEFILE_DIRECTORY}/../helm-charts/kubeinvaders \
+			--set ingress.enabled=true \
+			--set ingress.hostName=kubeinvaders.local \
+			--set deployment.image.tag=$(image_tag) \
+		&& minikube addons enable ingress
+
+.PHONY: develop
+develop: init-cluster dev-cluster
 
 .PHONY: setup
 setup: init-cluster setup-cluster

--- a/minikube-setup/Makefile
+++ b/minikube-setup/Makefile
@@ -19,7 +19,7 @@ init-cluster:
 
 .PHONY: setup-cluster
 setup-cluster: 
-	kubectl apply -f manifests && helm install kubeinvaders --set-string config.target_namespace="namespace1\,namespace2" \
+	kubectl apply -f manifests && helm install kubeinvaders --set-string config.target_namespace="ns-1" \
 	-n kubeinvaders kubeinvaders/kubeinvaders --set ingress.enabled=true --set ingress.hostName=kubeinvaders.local --set deployment.image.tag=v1.9.6 && minikube addons enable ingress
 
 

--- a/minikube-setup/Makefile
+++ b/minikube-setup/Makefile
@@ -19,7 +19,7 @@ init-cluster:
 
 .PHONY: setup-cluster
 setup-cluster: 
-	kubectl apply -f manifests && helm install kubeinvaders --set-string config.target_namespace="namespace1,namespace2" \
+	kubectl apply -f manifests && helm install kubeinvaders --set-string config.target_namespace="namespace1\,namespace2" \
 	-n kubeinvaders kubeinvaders/kubeinvaders --set ingress.enabled=true --set ingress.hostName=kubeinvaders.local --set deployment.image.tag=v1.9.6 && minikube addons enable ingress
 
 


### PR DESCRIPTION
I installed the project with minikube and I noticed that the [Makefile](https://raw.githubusercontent.com/lucky-sideburn/kubeinvaders/8e165a3f08fcb92d62bd9ff9738e0a8a15ba298e/minikube-setup/Makefile) had an unescaped character in the `config.target_namespace` variable setting, then I also noticed that the example provided in [manifest](https://raw.githubusercontent.com/lucky-sideburn/kubeinvaders/8e165a3f08fcb92d62bd9ff9738e0a8a15ba298e/minikube-setup/manifests/nginx.yml) creates a Deployment in the namespace ns-1, so in order to have a quickstart I changed the target namespace from `namespace1\,namespace2` to `ns-1`.

I also added a `dev-cluster` option into the Makefile to test the local changes applied to the helm chart.